### PR TITLE
Add NextJS/Coraza and Payload CMS application profiles + PCRE tuning guide

### DIFF
--- a/src/waf-rule-management/references/antipatterns-and-troubleshooting.md
+++ b/src/waf-rule-management/references/antipatterns-and-troubleshooting.md
@@ -57,6 +57,9 @@ Do not silently accept antipatterns. Proactively steer toward best practices.
 | **Excluding entire rule when only one param triggers** | Loses protection for other inputs | Use ctl:ruleRemoveTargetById=ID;ARGS:param |
 | **No condition on exclusion** | Applies to all traffic | Add REQUEST_URI, REQUEST_METHOD, etc. |
 | **Exclusion in wrong file** | Won't take effect | BEFORE-CRS for runtime; AFTER-CRS for configure-time |
+| **Regex in `ctl:ruleRemoveTargetById`** | Silently fails — ModSec ignores regex target selectors; rule still fires | Use a literal name: `ctl:ruleRemoveTargetById=933150;REQUEST_COOKIES:session-token` |
+| **`ctl:ruleRemoveTargetById` on a chained rule** | Target exclusion doesn't propagate through chain links; chain still matches | Use `ctl:ruleRemoveById=RULE_ID` scoped to the URI instead |
+| **Duplicate custom rule IDs** | Second rule silently overwrites first; one exclusion never runs | Assign unique IDs — use a counter (100001, 100002, …) and keep a project ID registry |
 
 ---
 

--- a/src/waf-rule-management/references/crs-application-profiles.md
+++ b/src/waf-rule-management/references/crs-application-profiles.md
@@ -71,6 +71,51 @@ SecRule REQUEST_URI "@beginsWith /blog/" \
 | Encoded state in URL | 942xxx | Scope by path; decode before matching |
 | Preflight (OPTIONS) | 911xxx | Usually allowed; verify method enforcement rules |
 
+### NextJS + Coraza (Caddy)
+
+No built-in CRS exclusion package. Write targeted exclusions for session token cookies.
+
+| FP Trigger | Typical Rules | Exclusion Approach |
+|-----------|---------------|-------------------|
+| `__Secure-next-auth.session-token` cookie with base64-encoded PHP-like substrings (`fputs`, `fclose`) | 933150 | `ctl:ruleRemoveTargetById=933150;REQUEST_COOKIES:__Secure-next-auth.session-token` — use **literal** cookie name, not regex |
+| Same session token containing `.env` substring | 930120 | `ctl:ruleRemoveTargetById=930120;REQUEST_COOKIES:__Secure-next-auth.session-token` |
+| `Next-Action` or other framework-specific headers | 920xxx | `ctl:ruleRemoveTargetByTag=920;REQUEST_HEADERS:Next-Action` scoped to SPA paths |
+
+> **Warning**: Regex patterns in `ctl:ruleRemoveTargetById` silently fail. Always use the exact, literal cookie or parameter name.
+
+```apache
+# Example: NextJS session token exclusions (place BEFORE CRS include)
+SecRule REQUEST_URI "@beginsWith /" \
+    "id:100010,phase:1,pass,nolog,t:none,\
+    ctl:ruleRemoveTargetById=933150;REQUEST_COOKIES:__Secure-next-auth.session-token"
+
+SecRule REQUEST_URI "@beginsWith /" \
+    "id:100011,phase:1,pass,nolog,t:none,\
+    ctl:ruleRemoveTargetById=930120;REQUEST_COOKIES:__Secure-next-auth.session-token"
+```
+
+### Payload CMS (REST API)
+
+No built-in CRS exclusion package. Rule 932370 fires at PL1 on any JSON body containing URL fields.
+
+| FP Trigger | Typical Rules | Exclusion Approach |
+|-----------|---------------|-------------------|
+| `POST /admin/collections/*` JSON body with `{"url": "..."}` | 932370 (PL1) | `ctl:ruleRemoveById=932370` scoped to `/admin/collections` — **must use `ctl:ruleRemoveById`**, not `ctl:ruleRemoveTargetById` (chain rule) |
+| `POST /api/pages/*` or other REST endpoints with URL fields in JSON | 932370 (PL1) | `ctl:ruleRemoveById=932370` scoped to `/api/` |
+
+> **Note**: Rule 932370 is a chained rule. `ctl:ruleRemoveTargetById` does not propagate through chain links and will silently fail. Use `ctl:ruleRemoveById` scoped narrowly by URI.
+
+```apache
+# Example: Payload CMS REST API exclusions (place BEFORE CRS include)
+SecRule REQUEST_URI "@beginsWith /admin/collections" \
+    "id:100020,phase:1,pass,nolog,t:none,\
+    ctl:ruleRemoveById=932370"
+
+SecRule REQUEST_URI "@beginsWith /api/" \
+    "id:100021,phase:1,pass,nolog,t:none,\
+    ctl:ruleRemoveById=932370"
+```
+
 ### Legacy/Custom Applications
 
 | Pattern | Approach |

--- a/src/waf-rule-management/references/false-positives-and-tuning.md
+++ b/src/waf-rule-management/references/false-positives-and-tuning.md
@@ -12,6 +12,21 @@ Goal: reduce false positives while preserving detection depth.
 - ModSecurity v3 directive/action details:
   <https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)>
 
+## Capture Configuration Context First
+
+Before analyzing or writing any exclusion, collect the following. Without this context, exclusion recommendations are speculative — the same rule ID fires for entirely different reasons depending on platform and paranoia level.
+
+| Field | What to capture |
+|-------|----------------|
+| **Paranoia level** | `blocking_paranoia_level` and `detection_paranoia_level` from `crs-setup.conf` |
+| **Engine + version** | ModSecurity v2/v3 or Coraza; WAF host (Apache, Nginx, Caddy) |
+| **CRS version** | e.g. `4.0.0`, `4.19.0` |
+| **Application / platform** | WordPress, NextJS, PrestaShop, Payload CMS, custom API, etc. |
+| **Triggering payload** | URI, HTTP method, relevant headers, body snippet, or cookie value that caused the match |
+| **Rule ID + matched variable** | From the audit or error log (e.g. `id:933150`, matched on `REQUEST_COOKIES:session-token`) |
+
+Ask the user for these details if they are not provided before proceeding.
+
 ## Standard Tuning Workflow
 
 1. Reproduce with controlled test traffic (same path, params, headers, body).

--- a/src/waf-rule-management/references/modsec-directives.md
+++ b/src/waf-rule-management/references/modsec-directives.md
@@ -53,6 +53,21 @@ Key ModSecurity v3 directives for rule operations, engine configuration, and log
 
 **Note**: These are v2-only. ModSecurity v3 uses compile-time PCRE limits. As of 2025, v3 is transitioning to PCRE2 as the default engine. See [regex-steering-guide.md](regex-steering-guide.md) for PCRE2 migration.
 
+### PCRE Limit Tuning (v2)
+
+`MSC_PCRE_LIMITS_EXCEEDED` (rule 200004) is the most frequently reported false positive class in ModSecurity v2 deployments. It is typically triggered by long query strings from social media tracking parameters (Facebook, Google Ads UTM chains) and complex ad-campaign URLs — not by malicious traffic.
+
+Community-validated safe values:
+
+| Profile | `SecPcreMatchLimit` | Notes |
+|---------|---------------------|-------|
+| Default (unchanged) | 1000 | Blocks some legitimate ad-campaign traffic |
+| Most production sites | 1500–2000 | Handles social media tracking params; recommended starting point |
+| Low-traffic sites | up to 10 000 | Acceptable when request volume is small |
+| Vendor suggestion (avoid) | 250 000 | Community consensus: causes resource exhaustion under load |
+
+Raise these limits **only** when audit logs confirm 200004 is triggering on legitimate traffic (tracking params, long query strings) and your regexes have been validated with `lint_regex.py`. Do not raise limits as a substitute for fixing ReDoS-prone patterns.
+
 ---
 
 ## Best Practices
@@ -70,7 +85,7 @@ Key ModSecurity v3 directives for rule operations, engine configuration, and log
 - **`SecRuleEngine Off`** as a troubleshooting shortcut — use `DetectionOnly` instead.
 - **`SecAuditLogParts ABCDEFGHIJKZ`** — logging everything is expensive. Section K is not implemented in v3.
 - **`SecDebugLogLevel` above 3 in production** — massive log volume, performance impact.
-- **Raising `SecPcreMatchLimit`** instead of fixing ReDoS-prone regexes (v2).
+- **Raising `SecPcreMatchLimit`** as a substitute for fixing ReDoS-prone regexes (v2) — raising is appropriate for the 200004 tracking-param FP class when regexes are sound.
 - **Missing `SecTmpDir`/`SecDataDir`** — causes silent failures for body buffering and persistent collections.
 - **Editing CRS rule files directly** — use exclusion directives instead.
 


### PR DESCRIPTION
## Summary

Expands WAF rule management reference documentation with two new application-specific CRS exclusion profiles (NextJS + Coraza/Caddy, Payload CMS REST API) and adds critical guidance on PCRE limit tuning for ModSecurity v2. Also introduces a pre-analysis checklist for false positive investigation to ensure context is captured before writing exclusions.

## Type of Change

- [x] New/updated reference documentation

## Changes

- **crs-application-profiles.md**: Added two new application profiles with detailed exclusion tables and code examples:
  - NextJS + Coraza (Caddy): Session token cookie exclusions for rules 933150, 930120; includes warning about regex patterns in `ctl:ruleRemoveTargetById` silently failing
  - Payload CMS (REST API): Rule 932370 exclusions scoped to `/admin/collections` and `/api/` endpoints; clarifies that chained rules require `ctl:ruleRemoveById` instead of `ctl:ruleRemoveTargetById`

- **modsec-directives.md**: 
  - Added "PCRE Limit Tuning (v2)" section with community-validated `SecPcreMatchLimit` values (1500–2000 for most production sites)
  - Clarified that raising limits is appropriate for the 200004 tracking-parameter false positive class when regexes are sound
  - Updated anti-pattern guidance to reflect this nuance

- **false-positives-and-tuning.md**: Added "Capture Configuration Context First" section with a table of required fields (paranoia level, engine version, CRS version, application platform, triggering payload, rule ID + matched variable) to collect before analyzing exclusions

- **antipatterns-and-troubleshooting.md**: Added three new antipatterns:
  - Regex in `ctl:ruleRemoveTargetById` silently fails
  - `ctl:ruleRemoveTargetById` on chained rules doesn't propagate
  - Duplicate custom rule IDs cause silent overwrites

## Checklist

- [x] New/updated reference docs are linked from progressive loading index (existing docs structure)
- [x] Markdown passes lint (no syntax errors)
- [x] Changes follow existing documentation style and structure

## Related Issues

Addresses common false positive patterns in NextJS/Coraza and Payload CMS deployments; provides actionable guidance for PCRE tuning in ModSecurity v2 based on community validation.

https://claude.ai/code/session_01Jxuy7WoUQrcZb2op9gqjn1